### PR TITLE
Fix dangling else parse errors

### DIFF
--- a/AlphaParser/AlphaCompiler/AlphaParser.g4
+++ b/AlphaParser/AlphaCompiler/AlphaParser.g4
@@ -53,7 +53,7 @@ statement
     | designator LPAREN actPars? RPAREN SEMI                   #callStatement
     | designator INC SEMI                                      #incStatement
     | designator DEC SEMI                                      #decStatement
-    | IF LPAREN condition RPAREN statement (ELSE statement)?   #ifStatement
+    | IF LPAREN condition RPAREN block (ELSE block)?           #ifStatement
     | FOR LPAREN expr? SEMI condition? SEMI expr? RPAREN statement #forStatement
     | WHILE LPAREN condition RPAREN statement                  #whileStatement
     | BREAK SEMI                                               #breakStatement

--- a/AlphaParser/AlphaCompiler/Content/Checker/AlphaChecker.cs
+++ b/AlphaParser/AlphaCompiler/Content/Checker/AlphaChecker.cs
@@ -351,9 +351,9 @@ namespace AlphaCompiler.Semantics
             if (condVal is bool b)
             {
                 if (b)
-                    Visit(ctx.statement(0));
-                else if (ctx.statement().Length > 1)
-                    Visit(ctx.statement(1));
+                    Visit(ctx.block(0));
+                else if (ctx.block().Length > 1)
+                    Visit(ctx.block(1));
             }
             else
             {

--- a/AlphaParser/AlphaCompiler/Content/parser/generated/AlphaParser.cs
+++ b/AlphaParser/AlphaCompiler/Content/parser/generated/AlphaParser.cs
@@ -954,12 +954,12 @@ public partial class AlphaParser : Parser {
 			return GetRuleContext<ConditionContext>(0);
 		}
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode RPAREN() { return GetToken(AlphaParser.RPAREN, 0); }
-		[System.Diagnostics.DebuggerNonUserCode] public StatementContext[] statement() {
-			return GetRuleContexts<StatementContext>();
-		}
-		[System.Diagnostics.DebuggerNonUserCode] public StatementContext statement(int i) {
-			return GetRuleContext<StatementContext>(i);
-		}
+                [System.Diagnostics.DebuggerNonUserCode] public BlockContext[] block() {
+                        return GetRuleContexts<BlockContext>();
+                }
+                [System.Diagnostics.DebuggerNonUserCode] public BlockContext block(int i) {
+                        return GetRuleContext<BlockContext>(i);
+                }
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode ELSE() { return GetToken(AlphaParser.ELSE, 0); }
 		public IfStatementContext(StatementContext context) { CopyFrom(context); }
 		[System.Diagnostics.DebuggerNonUserCode]
@@ -1165,19 +1165,19 @@ public partial class AlphaParser : Parser {
 				State = 138;
 				Match(RPAREN);
 				State = 139;
-				statement();
-				State = 142;
-				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,9,Context) ) {
-				case 1:
-					{
-					State = 140;
-					Match(ELSE);
-					State = 141;
-					statement();
-					}
-					break;
-				}
+                                block();
+                                State = 142;
+                                ErrorHandler.Sync(this);
+                                switch ( Interpreter.AdaptivePredict(TokenStream,9,Context) ) {
+                                case 1:
+                                        {
+                                        State = 140;
+                                        Match(ELSE);
+                                        State = 141;
+                                        block();
+                                        }
+                                        break;
+                                }
 				}
 				break;
 			case 6:

--- a/AlphaParser/AlphaCompiler/test.txt
+++ b/AlphaParser/AlphaCompiler/test.txt
@@ -58,5 +58,14 @@ class Main {
         print(len(arrD));         // 0
         print(len(arrC));         // 0
         print(len(arrB));         // 0
+
+        if (num == 65) {
+            print(1);           // se imprime
+        } else {
+            print(0);
+        }
+        if (num != 65) {
+            print(0);           // no se imprime
+        }
     }
 }


### PR DESCRIPTION
## Summary
- require blocks for `if` statements in the grammar
- adapt semantic checker for the new rule
- patch generated parser accordingly
- extend `test.txt` with an additional `if` example

## Testing
- `dotnet build AlphaParser/AlphaCompiler/AlphaCompiler.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfa58c4a88331a3d86d2b68f454fe